### PR TITLE
Switch updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ This script has two subcommands:
 **`loop`** scans one or more Tomcat (or Apache?) log files for repeated entries, consistent with the looping behavior we saw on the new production IdP from its launch in October 2020 through the fix in February 2021. **(Loop checking was removed in commit #bf21dda)**
 
 **`sp`** scans one or more `idp-process.log` files to see which service providers have received attributes from the IdP.
+**(sp was removed in commit #6beab69)**
 
 ### Filenames
 
@@ -74,3 +75,5 @@ For `sp`, there are two:
 **`-i3`** is necessary for parsing IdP version 3 logfiles; they are in a slightly different format that cant’t easily be detected. If you forget, the only SP that shows up is “`http://shibboleth.net/ns/profiles/saml2/sso/browser`” **(-i3 was removed in commit #0a61bde. Only IdP version 4 is supported now)**
 
 **`-r [entity_id]`** lets you specify a single relying party’s entity id, and _only_ processes connections to that SP. In addition to the simple count, it also outputs the list of users who have used it and the number of times for each.
+
+**`-n [username]`** lets you specify a username and return the relying party IDs 

--- a/logcheck.py
+++ b/logcheck.py
@@ -63,20 +63,20 @@ def relying_parties(args):
 if __name__ == '__main__':
     argp = ArgumentParser()
     argp.set_defaults(command=help)
-    subp = argp.add_subparsers(help=f'{__file__} {{command}} -h for more help')
+    # subp = argp.add_subparsers(help=f'{__file__} {{command}} -h for more help')
 
 
-    sp_p = subp.add_parser('sp', help='Service providers that used the IdP')
-    sp_p.add_argument('-f', '--filename', type=str, nargs='*',
-                      default=['/opt/shibboleth-idp/logs/idp-process.log'],
+    # sp_p = subp.add_parser('sp', help='Service providers that used the IdP')
+    argp.add_argument('-f', '--filename', type=str, nargs='*',
+                       default=['/opt/shibboleth-idp/logs/idp-process.log'],
                       help='Log filename(s) to process, accepts wildcards')
-    sp_p.add_argument('-i', '--idp-version', default=4,
+    argp.add_argument('-i', '--idp-version', default=4,
                       help='IdP version')
-    sp_p.add_argument('-r', '--relying-party', default=None, nargs='*',
+    argp.add_argument('-r', '--relying-party', default=None, nargs='*',
                       help='Restrict to this relying party and list users')
-    sp_p.add_argument('-n', '--name', default=None, nargs='*',
+    argp.add_argument('-n', '--name', default=None, nargs='*',
                       help='Restrict to this entity id and list relying parties') # takes a username and returns the relying party IDs (with counts)
-    sp_p.set_defaults(command=service_providers)
+    argp.set_defaults(command=service_providers)
 
     args = argp.parse_args()
     if args.command:

--- a/logcheck.py
+++ b/logcheck.py
@@ -17,11 +17,17 @@ def loops(args):
 
 
 def service_providers(args):
-    # if a username has been specified, then deal with that in relying_parties
-    if args.name:
-        relying_parties(args)
-        if args.relying_party == []:
-            return 0
+
+    # -r is not specified
+    if args.relying_party == None:
+        # neither -r nor -n specified
+        if args.name == None:
+            print("You must specify either -n or -r or both.")
+        # -n specified
+        else:
+            relying_parties(args)
+        return 0
+
     for party in args.relying_party: # allows for multiple party ID arguments
         kwargs = {
             'idpv': args.idp_version,
@@ -32,21 +38,27 @@ def service_providers(args):
             log.load(filename)
         log.command_service_providers()
 
+    # both -n and -r switches specified
+    if not args.name == None:
+        args.relying_party = None
+        relying_parties(args)
+
+
 # works similarly to service_providers: for a given username, print out each relying_party accessed by it
 def relying_parties(args):
+
      for name in args.name:
             kwargs = {
                 'idpv': args.idp_version,
                 'name': name,
             }
-            if args.relying_party == []:
-                kwargs['relying_party'] = None # we'll get an error if there's an empty list
+
+            kwargs['relying_party'] = args.relying_party   # we'll get an error if there's an empty list
 
             log = ShibbolethLog(**kwargs)
             for filename in args.filename:
                 log.load(filename)
             log.command_relying_parties()
-
 
 if __name__ == '__main__':
     argp = ArgumentParser()
@@ -60,7 +72,7 @@ if __name__ == '__main__':
                       help='Log filename(s) to process, accepts wildcards')
     sp_p.add_argument('-i', '--idp-version', default=4,
                       help='IdP version')
-    sp_p.add_argument('-r', '--relying-party', required=True, default=None, nargs='*',
+    sp_p.add_argument('-r', '--relying-party', default=None, nargs='*',
                       help='Restrict to this relying party and list users')
     sp_p.add_argument('-n', '--name', default=None, nargs='*',
                       help='Restrict to this entity id and list relying parties') # takes a username and returns the relying party IDs (with counts)


### PR DESCRIPTION
Makes -r and -n switches optional but prints an error if neither one has been specified. Also removes the sp subcommand since logcheck is only doing one thing now. 